### PR TITLE
fix french translation for activated and deactivated labels

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -9,8 +9,8 @@
     <string name="setting">réglage</string>
     <string name="theme">thème</string>
     <string name="sound">sons</string>
-    <string name="on">aktivieren</string>
-    <string name="off">deaktivieren</string>
+    <string name="on">activer</string>
+    <string name="off">désactiver</string>
     <string name="version">version</string>
     <string name="reminder">rappel</string>
 </resources>


### PR DESCRIPTION
Hello,

I'm a french user of the application, and I've noticed these 2 untranslated labels, so, I propose this fix :)
